### PR TITLE
Fix pod for tensorflow v1.4.0

### DIFF
--- a/TensorflowPod.podspec
+++ b/TensorflowPod.podspec
@@ -66,7 +66,7 @@ Pod::Spec.new do |s|
   #
 
   s.ios.framework  = "Accelerate"
-  s.ios.vendored_libraries = "lib/libtensorflow-core.a", "lib/libprotobuf-lite.a", "lib/libprotobuf.a"
+  s.ios.vendored_libraries = "lib/libtensorflow-core.a", "lib/libprotobuf-lite.a", "lib/libprotobuf.a", "lib/libnsync.a"
 
   # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #
@@ -81,6 +81,7 @@ Pod::Spec.new do |s|
       "${PODS_ROOT}/#{s.name}/include/tensorflow/contrib/makefile/downloads",
       "${PODS_ROOT}/#{s.name}/include/tensorflow/contrib/makefile/downloads/eigen",
       "${PODS_ROOT}/#{s.name}/include/tensorflow/contrib/makefile/gen/proto",
+      "${PODS_ROOT}/#{s.name}/include/tensorflow/contrib/makefile/downloads/nsync/public",
     ],
     "OTHER_LDFLAGS" => "-force_load $(PODS_ROOT)/#{s.name}/lib/libtensorflow-core.a" 
   }

--- a/pack.sh
+++ b/pack.sh
@@ -9,4 +9,10 @@ tar rvf $TAR -s '/^./include/' ./tensorflow/contrib/makefile/downloads/eigen/uns
 tar rvf $TAR -s '/^./include/' ./tensorflow/contrib/makefile/downloads/eigen/Eigen
 (cd tensorflow/contrib/makefile/gen; tar rvf ../../../../$TAR lib/libtensorflow-core.a)
 (cd tensorflow/contrib/makefile/gen/protobuf_ios; tar rvf ../../../../../$TAR lib/libprotobuf-lite.a lib/libprotobuf.a)
+# Renaming nsync.a and moving it into a temporary lib directory to have all tensorflow static libraries under the same folder.
+# It would be nice if instead of copy/rename and then remove nsync.a it would be possible to do it all directly with tar.
+mkdir -p tensorflow/contrib/makefile/downloads/nsync/builds/lib
+cp tensorflow/contrib/makefile/downloads/nsync/builds/lipo.ios.c++11/nsync.a tensorflow/contrib/makefile/downloads/nsync/builds/lib/libnsync.a 
+(cd tensorflow/contrib/makefile/downloads/nsync/builds; tar rvf ../../../../../../$TAR lib/libnsync.a)
 gzip $TAR
+rm tensorflow/contrib/makefile/downloads/nsync/builds/lib/libnsync.a


### PR DESCRIPTION
Hi, 

The current pod does not compile because of this error.
https://github.com/tensorflow/tensorflow/issues/12482.

Those changes should fix it.

BTW - You can update the tar by copying it from here:
https://github.com/tomergafner/TensorflowPod/releases/download/v1.4.0-fix/tensorflow.tar.gz
and the main difference is that it now contains the library libnsync.a which is now required by the framework. 

Cheers !